### PR TITLE
Unbound built from source as static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget -q https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.ta
     rm unbound.tar.gz
 RUN CFLAGS=${CFLAGS} ./configure --disable-flto --with-libevent --with-conf-file=unbound.conf
 RUN sed -i 's/LDFLAGS=.*$/LDFLAGS=-all-static/' Makefile
-RUN make
+RUN make && strip unbound
 
 FROM ${BASE_IMAGE}:${ALPINE_VERSION} AS updated
 WORKDIR /tmp/updated
@@ -41,7 +41,7 @@ LABEL \
     org.opencontainers.image.source="https://github.com/qdm12/cloudflare-dns-server" \
     org.opencontainers.image.title="cloudflare-dns-server" \
     org.opencontainers.image.description="Runs a local DNS server connected to Cloudflare DNS server 1.1.1.1 over TLS (and more)" \
-    image-size="28MB" \
+    image-size="27.1MB" \
     ram-usage="13.2MB to 70MB" \
     cpu-usage="Low"
 EXPOSE 53/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.10
 
+FROM ${BASE_IMAGE}:${ALPINE_VERSION} AS build
+ARG UNBOUND_VERSION=1.9.4
+ARG CFLAGS=-Os
+WORKDIR /tmp/unbound
+RUN apk add --update --progress -q ca-certificates build-base libressl-dev expat-dev libevent-dev libevent-static
+RUN wget -q https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz -O unbound.tar.gz && \
+    tar -xzf unbound.tar.gz --strip-components=1 && \
+    rm unbound.tar.gz
+RUN CFLAGS=${CFLAGS} ./configure --disable-flto --with-libevent --with-conf-file=unbound.conf
+RUN sed -i 's/LDFLAGS=.*$/LDFLAGS=-all-static/' Makefile
+RUN make
+
 FROM ${BASE_IMAGE}:${ALPINE_VERSION} AS updated
 WORKDIR /tmp/updated
 RUN wget -q https://raw.githubusercontent.com/qdm12/updated/master/files/named.root.updated -O root.hints && \
@@ -45,23 +57,24 @@ ENTRYPOINT /unbound/entrypoint.sh
 HEALTHCHECK --interval=5m --timeout=15s --start-period=5s --retries=1 \
     CMD LISTENINGPORT=${LISTENINGPORT:-53}; dig @127.0.0.1 +short +time=1 duckduckgo.com -p $LISTENINGPORT &> /dev/null; [ $? = 0 ] || exit 1
 WORKDIR /unbound
-RUN apk --update --progress -q add ca-certificates unbound bind-tools libcap && \
+RUN apk --update --progress -q add ca-certificates bind-tools && \
+    rm -rf /var/cache/apk/* && \
     adduser nonrootuser -D -H --uid 1000 && \
-    chown nonrootuser /usr/sbin/unbound && \
-    chmod 500 /usr/sbin/unbound && \
-    setcap 'cap_net_bind_service=+ep' /usr/sbin/unbound && \
-    apk del libcap && \
     mv /etc/ssl/certs/ca-certificates.crt . && \
-    rm -rf /var/cache/apk/* /etc/unbound /usr/sbin/unbound-*
-COPY --from=updated /tmp/updated/root.hints .
-COPY --from=updated /tmp/updated/root.key .
-COPY --from=updated /tmp/updated/blocks-malicious.bz2 .
-COPY --from=updated /tmp/updated/blocks-nsa.bz2 .
-COPY unbound.conf entrypoint.sh ./
-RUN chown nonrootuser -R . && \
-    chmod 700 . && \
-    chmod 600 unbound.conf && \
-    chmod 700 entrypoint.sh && \
+    chown nonrootuser . ca-certificates.crt && \
+    chmod 700 .
+COPY --from=build --chown=nonrootuser /tmp/unbound/unbound .
+COPY --from=updated --chown=nonrootuser /tmp/updated/root.hints .
+COPY --from=updated --chown=nonrootuser /tmp/updated/root.key .
+COPY --from=updated --chown=nonrootuser /tmp/updated/blocks-malicious.bz2 .
+COPY --from=updated --chown=nonrootuser /tmp/updated/blocks-nsa.bz2 .
+COPY --chown=nonrootuser unbound.conf entrypoint.sh ./
+RUN chmod 600 unbound.conf && \
+    chmod 500 entrypoint.sh && \
+    chmod 500 unbound && \
     chmod 400 root.hints root.key ca-certificates.crt *.bz2 && \
-    mv /usr/sbin/unbound .
+    apk add libcap && \
+    setcap 'cap_net_bind_service,cap_sys_chroot=+ep' unbound && \
+    apk del libcap && \
+    rm -rf /var/cache/apk/*
 USER nonrootuser

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It can be connected to one or more of the following DNS-over-TLS providers:
 <details><summary>Click to show base components</summary><p>
 
 - [Alpine 3.10](https://alpinelinux.org)
-- [Unbound 1.9.1-r2](https://pkgs.alpinelinux.org/package/v3.10/main/x86_64/unbound)
+- [Unbound 1.9.4](https://nlnetlabs.nl/downloads/unbound) built from source
 - [Files and lists built periodically](https://github.com/qdm12/updated/tree/master/files)
 - [bind-tools](https://pkgs.alpinelinux.org/package/v3.10/main/x86_64/bind-tools) for the healthcheck with `dig`
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ See [this](http://www.macinstruct.com/node/558)
 ### Build the image yourself
 
 ```bash
-docker build -t qmcgaw/cloudflare-dns-server https://github.com/qdm12/cloudflare-dns-server.git
+# Docker Build Kit to carry OS capabilities of unbound from build image to final image
+DOCKER_BUILDKIT=1 docker build -t qmcgaw/cloudflare-dns-server https://github.com/qdm12/cloudflare-dns-server.git
 ```
 
 ### Firewall considerations

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 | Image size | RAM usage | CPU usage |
 | --- | --- | --- |
-| 28MB | 13.2MB to 70MB | Low |
+| 27.1MB | 13.2MB to 70MB | Low |
 
 It can be connected to one or more of the following DNS-over-TLS providers:
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-             --build-arg VCS_REF=`git rev-parse --short HEAD` \
-             -t $IMAGE_NAME .
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    -t $IMAGE_NAME .


### PR DESCRIPTION
- Static build of Unbound 1.9.4
- Final binary size of 2.4MB
- Permissions and capabilities of Unbound set at build stage using docker build kit