### PR TITLE
Fix caching logic

### DIFF
--- a/internal/dns/conf.go
+++ b/internal/dns/conf.go
@@ -103,9 +103,9 @@ func generateUnboundConf(settings models.Settings, client network.Client, logger
 		"forward-tls-upstream": "yes",
 	}
 	if settings.Caching {
-		forwardZoneSection["forward-no-cache"] = "yes"
-	} else {
 		forwardZoneSection["forward-no-cache"] = "no"
+	} else {
+		forwardZoneSection["forward-no-cache"] = "yes"
 	}
 	var forwardZoneLines []string
 	for k, v := range forwardZoneSection {

--- a/internal/dns/conf_test.go
+++ b/internal/dns/conf_test.go
@@ -79,7 +79,7 @@ server:
   private-address: c
   private-address: d
 forward-zone:
-  forward-no-cache: no
+  forward-no-cache: yes
   forward-tls-upstream: yes
   name: "."
   forward-addr: 1.1.1.1@853#cloudflare-dns.com


### PR DESCRIPTION
Hi :)

The caching logic is incorrect in the current revision: if the environment variable `CACHING=on` is passed, the value of the parameter `forward-no-cache` is set to yes, which is not the desired behavior, according to the official Unbound documentation (https://nlnetlabs.nl/documentation/unbound/unbound.conf/):

> forward-no-cache: <yes or no>
              Default  is  no.   If  enabled,  data  inside the forward is not
              cached.  This is useful when you want immediate  changes  to  be
              visible.

This PR is just an inversion of the two values set for `forward-no-cache`.