### PR TITLE
Fix default value for BLOCK_SURVEILLANCE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Diagrams are shown for router and client-by-client configurations in the [**Conn
 | `VERBOSITY` | `1` | From 0 (no log) to 5 (full debug log) |
 | `VERBOSITY_DETAILS` | `0` | From 0 to 4 (higher means more details) |
 | `BLOCK_MALICIOUS` | `on` | `on` or `off`, to block malicious IP addresses and malicious hostnames from being resolved |
-| `BLOCK_SURVEILLANCE` | `on` | `on` or `off`, to block surveillance IP addresses and hostnames from being resolved |
+| `BLOCK_SURVEILLANCE` | `off` | `on` or `off`, to block surveillance IP addresses and hostnames from being resolved |
 | `BLOCK_ADS` | `off` | `on` or `off`, to block ads IP addresses and hostnames from being resolved |
 | `BLOCK_HOSTNAMES` |  | comma separated list of hostnames to block from being resolved |
 | `BLOCK_IPS` |  | comma separated list of IPs to block from being returned to clients |


### PR DESCRIPTION
Hi again :)

Just a small fix for the README value of BLOCK_SURVEILLANCE, whose value is set to off by default in the Dockerfile.