### PR TITLE
Bumps golang version to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_VERSION=3.12
-ARG GO_VERSION=1.14
+ARG GO_VERSION=1.15
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 RUN apk --update add git


### PR DESCRIPTION
This bumps the golang version to 1.15.  I don't see anything major in the release notes (https://golang.org/doc/go1.15) that would be likely to benefit this container, but there are some binary size reductions and general improvements that seem good to bring it.

It builds for me, so hopefully that's enough testing.  If not, let me know what else I can do.